### PR TITLE
Update attendees.yml

### DIFF
--- a/_data/attendees.yml
+++ b/_data/attendees.yml
@@ -39,7 +39,7 @@
 - name: Simon Redding
   github_username: simonredding
   twitter_username: simonredding
-  email_hash: 97BE3D02F1F178FCF312C3AFFF00F1EE
+  email_hash: 97be3d02f1f178fcf312c3afff00f1ee
 
 - name: Ben Foxall
   github_username: benfoxall
@@ -54,9 +54,10 @@
 - name: Chris Seymour
   github_username: iiSeymour
   twitter_username: iiSeymour
-  email_hash: E7B454A133DC67FE54D058A13BAC9A67
-
+  email_hash: e7b454a133dc67fe54d058a13bac9a67
+  
 - name: Rich Douglas
   github_username: richdouglasevans
   twitter_username: richdevans
-  email_hash: 7A48DFCB39785E6524E005DF09CF0C98
+  email_hash: 7a48dfcb39785e6524e005df09cf0c98
+  


### PR DESCRIPTION
MD5's created with http://onlinemd5.com/ are uppercase however gravatar expects lower case. Avatars now show for @richdouglasevans and myself.
