### PR TITLE
update @simonredding's email hash

### DIFF
--- a/_data/attendees.yml
+++ b/_data/attendees.yml
@@ -39,7 +39,7 @@
 - name: Simon Redding
   github_username: simonredding
   twitter_username: simonredding
-  email_hash: 97be3d02f1f178fcf312c3afff00f1ee
+  email_hash: 63ae1f590468c9b2a96f3b8fda007b14
 
 - name: Ben Foxall
   github_username: benfoxall


### PR DESCRIPTION
Looks like the hash wasn't matching anything on gravatar, I've created a new one from the email on @simonredding's github profile.
